### PR TITLE
担当課担当係のツリー表示を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
     '書類正式名称',
     '書類略称',
     'タグ',
+    '場所種別',
     '内線番号',
     'score',
     'deviationValue',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -805,7 +805,7 @@ export default function Home() {
                                           })}
                                         >{`${item2[groupByKeys[2]]}${
                                           item2.data[0]['場所'] !== ''
-                                            ? `（${item2.data[0]['場所']}）`
+                                            ? `（${item2.data[0]['場所'].replace(';', '・')}）`
                                             : ''
                                         }`}</div>
                                       </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -708,7 +708,9 @@ export default function Home() {
                                 key={`result-group-item-${j}`}
                                 className={css({
                                   margin: '0',
-                                  padding: '1em 0 0 1.5em',
+                                  padding: item1[groupByKeys[1]]
+                                    ? '1em 0 0 1.5em'
+                                    : '0',
                                   position: 'relative',
                                   _before: {
                                     content: '""',
@@ -732,19 +734,25 @@ export default function Home() {
                                   },
                                 })}
                               >
-                                <div
-                                  className={css({
-                                    borderRadius: '4px',
-                                    border: '1px solid #afafaf',
-                                    backgroundColor: 'white',
-                                    margin: '0',
-                                    padding: '0.5em',
-                                    maxWidth: '20em',
-                                  })}
-                                >{`${item1[groupByKeys[1]]}`}</div>
+                                {item1[groupByKeys[1]] && (
+                                  <h5
+                                    className={css({
+                                      borderRadius: '4px',
+                                      border: '1px solid #afafaf',
+                                      backgroundColor: 'white',
+                                      margin: '0',
+                                      padding: '0.5em',
+                                      maxWidth: '14em',
+                                      fontSize: '16px',
+                                      fontWeight: 'normal',
+                                    })}
+                                  >{`${item1[groupByKeys[1]]}`}</h5>
+                                )}
                                 <ul
                                   className={css({
-                                    margin: '0 0 0 2em',
+                                    margin: item1[groupByKeys[1]]
+                                      ? '0 0 0 2em'
+                                      : '0',
                                     padding: '0',
                                     position: 'relative',
                                     _before: {
@@ -805,7 +813,9 @@ export default function Home() {
                                           })}
                                         >{`${item2[groupByKeys[2]]}${
                                           item2.data[0]['場所'] !== ''
-                                            ? `（${item2.data[0]['場所'].replace(';', '・')}）`
+                                            ? `（${item2.data[0][
+                                                '場所'
+                                              ].replace(';', '・')}）`
                                             : ''
                                         }`}</div>
                                       </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   const debug = searchParams.get('debug')
   const resultTitleRef = useRef<HTMLHeadingElement>(null)
 
-  const groupByKeys = ['担当課', '担当係']
+  const groupByKeys = ['場所種別', '担当課', '担当係']
   const excludeDisplayKeys = [
     '手続名称',
     '書類正式名称',
@@ -703,7 +703,7 @@ export default function Home() {
                               },
                             })}
                           >
-                            {resultGroup.data.map((item, j) => (
+                            {resultGroup.data.map((item1, j) => (
                               <li
                                 key={`result-group-item-${j}`}
                                 className={css({
@@ -741,11 +741,77 @@ export default function Home() {
                                     padding: '0.5em',
                                     maxWidth: '20em',
                                   })}
-                                >{`${item[groupByKeys[1]]}${
-                                  item.data[0]['場所'] !== ''
-                                    ? `（${item.data[0]['場所']}）`
-                                    : ''
-                                }`}</div>
+                                >{`${item1[groupByKeys[1]]}`}</div>
+                                <ul
+                                  className={css({
+                                    margin: '0 0 0 2em',
+                                    padding: '0',
+                                    position: 'relative',
+                                    _before: {
+                                      content: '""',
+                                      display: 'block',
+                                      width: '0',
+                                      position: 'absolute',
+                                      top: '0',
+                                      bottom: '0',
+                                      left: '0',
+                                      borderLeft: '1px solid',
+                                      backgroundColor: 'white',
+                                    },
+                                  })}
+                                >
+                                  {item1.data.map(
+                                    (
+                                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                      item2: any,
+                                      k: number
+                                    ) => (
+                                      <li
+                                        key={`item-${j}-${k}`}
+                                        className={css({
+                                          margin: '0',
+                                          padding: '1em 0 0 1.5em',
+                                          position: 'relative',
+                                          _before: {
+                                            content: '""',
+                                            borderTop: '1px solid',
+                                            display: 'block',
+                                            height: '100%',
+                                            left: '0',
+                                            marginTop: '1em',
+                                            position: 'absolute',
+                                            top: '1.5em',
+                                            width: '1.5em',
+                                          },
+                                          _last: {
+                                            _before: {
+                                              content: '""',
+                                              bottom: '0',
+                                              height: 'auto',
+                                              top: '1.5em',
+                                              backgroundColor: 'white',
+                                            },
+                                          },
+                                        })}
+                                      >
+                                        <div
+                                          className={css({
+                                            borderRadius: '4px',
+                                            border: '1px solid #afafaf',
+                                            backgroundColor: 'white',
+                                            margin: '0',
+                                            padding: '0.5em',
+                                            maxWidth: '20em',
+                                          })}
+                                        >{`${item2[groupByKeys[2]]}${
+                                          item2.data[0]['場所'] !== ''
+                                            ? `（${item2.data[0]['場所']}）`
+                                            : ''
+                                        }`}</div>
+                                      </li>
+                                    )
+                                  )}
+                                </ul>
                               </li>
                             ))}
                           </ul>

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -10,14 +10,31 @@ export const getGroupByKey = (
 ): GroupByKeyObject[] =>
   Object.values(
     arr.reduce((res, item) => {
-      const value = item[key]
-      const existing = res[value] || { [key]: value, data: [] }
-      return {
-        ...res,
-        [value]: {
-          ...existing,
-          data: [...existing.data, item],
-        },
+      if (item[key] !== undefined && item[key].includes(';')) {
+        const values = item[key].split(';')
+        const mappedArr = values.map((value: string) => {
+          const existing = res[value] || { [key]: value, data: [] }
+          return {
+            ...existing,
+            data: [...existing.data, item],
+          }
+        })
+        return mappedArr.reduce((res: any, item: { [x: string]: any }) => {
+          return {
+            ...res,
+            [item[key]]: item,
+          }
+        }, {})
+      } else {
+        const value = item[key]
+        const existing = res[value] || { [key]: value, data: [] }
+        return {
+          ...res,
+          [value]: {
+            ...existing,
+            data: [...existing.data, item],
+          },
+        }
       }
     }, {})
   )

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -60,7 +60,7 @@ export const getConcatResults = (obj: object, concatDisplayKeys: string[]) => {
   const concatResults = Object.entries(obj)
     .filter(([k]) => concatDisplayKeys.includes(k))
     .map(([, value]) => {
-      return value as string
+      return value.replace(';', '・')
     })
   return concatResults.join(' ')
 }


### PR DESCRIPTION
- セミコロン区切りに対応
- 場所種別を追加
- 担当課が空欄だったときの条件分岐を追加

![スクリーンショット 2023-08-25 13 24 44](https://github.com/code4nerima/inside-gov-search-frontend/assets/14883063/8e5a0f08-f2df-4aee-9801-6572d6ee7496)

![スクリーンショット 2023-08-25 13 27 10](https://github.com/code4nerima/inside-gov-search-frontend/assets/14883063/4b666794-e413-46a2-8b7a-c9950c82a757)
