### PR TITLE
suggestedPromptsを検索時も表示を残すように修正

### DIFF
--- a/src/app/components/SuggestedPromptsBlock.tsx
+++ b/src/app/components/SuggestedPromptsBlock.tsx
@@ -3,11 +3,12 @@ import { css } from '../../../styled-system/css'
 
 export default function SuggestedPromptsBlock(props: {
   suggestedPrompts: string[]
+  disabled: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onChangePrompt: any
   doClear: boolean
 }) {
-  const { suggestedPrompts, onChangePrompt, doClear } = props
+  const { suggestedPrompts, disabled, onChangePrompt, doClear } = props
   const [selectedValue, setSelectedValue] = useState('')
 
   const handleChangePrompt = (e: { target: { value: string } }) => {
@@ -61,11 +62,15 @@ export default function SuggestedPromptsBlock(props: {
               className={css({
                 marginRight: '8px',
                 cursor: 'pointer',
+                _disabled: {
+                  cursor: 'wait',
+                },
               })}
               id={`suggested-prompt-id-${i}`}
               name="suggested-prompt"
               value={prompt}
               checked={selectedValue === prompt}
+              disabled={disabled}
               onChange={handleChangePrompt}
             />
             <label

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,6 +60,7 @@ export default function Home() {
   const [isResultResponded, setIsResultResponded] = useState(false)
   const [isSuggestedPromptResponded, setIsSuggestedPromptResponded] =
     useState(false)
+  const [isPromptSelected, setIsPromptSelected] = useState(false)
   const [isComposed, setIsComposed] = useState(false)
   const [isFontReady, setIsFontReady] = useState(false)
   const [isRecording, setIsRecording] = useState(false)
@@ -93,6 +94,7 @@ export default function Home() {
       setSynonym(data.results.synonyms)
       setIsResultResponded(true)
       setIsSearchExecuting(false)
+      setIsPromptSelected(false)
       await suggestPrompt(prompt)
     } catch (error) {
       if (error instanceof Error) {
@@ -103,6 +105,7 @@ export default function Home() {
     } finally {
       setIsResultResponded(true)
       setIsSearchExecuting(false)
+      setIsPromptSelected(false)
     }
   }
 
@@ -146,17 +149,19 @@ export default function Home() {
     setResultsGroupBy([])
     setKeyword('')
     setSynonym('')
-    setSuggestedPrompts([])
     setIsResultResponded(false)
     setIsSuggestedPromptResponded(false)
   }
 
   const handleClearAll = () => {
+    setIsPromptSelected(false)
     setCurrentPrompt('')
+    setSuggestedPrompts([])
     handleReset()
   }
 
   const handleChangePrompt = async (prompt: string) => {
+    setIsPromptSelected(true)
     setCurrentPrompt(prompt)
     await handleSearch(prompt)
   }
@@ -524,7 +529,7 @@ export default function Home() {
                   )}
                 </div>
               </div>
-              {isSuggestedPromptResponded ? (
+              {isSuggestedPromptResponded || isPromptSelected ? (
                 <div
                   className={css({
                     width: 'min(97%, 650px)',
@@ -534,6 +539,7 @@ export default function Home() {
                   <SuggestedPromptsBlock
                     suggestedPrompts={suggestedPrompts}
                     onChangePrompt={handleChangePrompt}
+                    disabled={isSearchExecuting}
                     doClear={currentPrompt === ''}
                   />
                 </div>


### PR DESCRIPTION
サジェストされたプロンプトを選択時に非表示にするのが不自然だったので、検索実行中はradioボタンをdisabledにしつつ、表示を残すようにしました。

![スクリーンショット 2023-09-23 0 49 52](https://github.com/code4nerima/inside-gov-search-frontend/assets/14883063/3c87fa7d-3107-49bb-bc60-23f9d95688cd)
